### PR TITLE
fix(*): Update yamllint preset syntax

### DIFF
--- a/go/flake.nix
+++ b/go/flake.nix
@@ -15,15 +15,25 @@
     extra-substituters = "https://devenv.cachix.org";
   };
 
-  outputs = inputs@{ flake-parts, nixpkgs, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = inputs @ {
+    flake-parts,
+    nixpkgs,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       imports = [
         inputs.devenv.flakeModule
       ];
-      systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      systems = ["x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
 
-      perSystem = { config, self', inputs', pkgs, system, ... }:
-        {
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: {
         # Per-system attributes can be defined here. The self' and inputs'
         # module parameters provide easy access to attributes of the same
         # system.
@@ -38,8 +48,7 @@
           ];
 
           # https://devenv.sh/reference/options/
-          packages = with pkgs;
-            [gopls];
+          packages = with pkgs; [gopls];
 
           # https://devenv.sh/basics/
           env = {
@@ -62,25 +71,20 @@
           # https://devenv.sh/pre-commit-hooks/
           pre-commit.hooks = {
             nixfmt.enable = true;
-            yamllint.enable = true;
-          };
-
-          # Plugin configuration
-          pre-commit.settings = {
-            yamllint.relaxed = true;
+            yamllint = {
+              enable = true;
+              settings.preset = "relaxed";
+            };
           };
 
           # https://devenv.sh/integrations/dotenv/
           dotenv.enable = true;
-
         };
-
       };
       flake = {
         # The usual flake attributes can be defined here, including system-
         # agnostic ones like nixosModule and system-enumerating ones, although
         # those are more easily expressed in perSystem.
-
       };
     };
 }

--- a/javascript/flake.nix
+++ b/javascript/flake.nix
@@ -10,73 +10,73 @@
     extra-substituters = "https://devenv.cachix.org";
   };
 
-  outputs = { self, nixpkgs, devenv, systems, ... } @ inputs:
-    let
-      forEachSystem = nixpkgs.lib.genAttrs (import systems);
-    in
-    {
-      devShells = forEachSystem
-        (system:
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-            nodejs-packages = with pkgs.nodePackages; [
-              vscode-langservers-extracted
-              typescript-language-server
-              yarn
-            ];
-          in
-          {
-            default = devenv.lib.mkShell {
-              inherit inputs pkgs;
-              modules = [
-                {
-                  # https://devenv.sh/basics/
-                  env = {
-                    GREET = "🛠️ Let's hack 🧑🏻‍💻";
-                  };
+  outputs = {
+    self,
+    nixpkgs,
+    devenv,
+    systems,
+    ...
+  } @ inputs: let
+    forEachSystem = nixpkgs.lib.genAttrs (import systems);
+  in {
+    devShells =
+      forEachSystem
+      (system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        nodejs-packages = with pkgs.nodePackages; [
+          vscode-langservers-extracted
+          typescript-language-server
+          yarn
+        ];
+      in {
+        default = devenv.lib.mkShell {
+          inherit inputs pkgs;
+          modules = [
+            {
+              # https://devenv.sh/basics/
+              env = {
+                GREET = "🛠️ Let's hack 🧑🏻‍💻";
+              };
 
-                  # https://devenv.sh/reference/options/
-                  packages = with pkgs;
-                    [] ++ nodejs-packages;
+              # https://devenv.sh/reference/options/
+              packages = with pkgs;
+                [] ++ nodejs-packages;
 
-                  # https://devenv.sh/scripts/
-                  scripts.hello.exec = "echo $GREET";
+              # https://devenv.sh/scripts/
+              scripts.hello.exec = "echo $GREET";
 
-                  enterShell = ''
-                    hello
-                  '';
+              enterShell = ''
+                hello
+              '';
 
-                  # https://devenv.sh/languages/
-                  languages.javascript = {
-                    enable = true;
-                  };
+              # https://devenv.sh/languages/
+              languages.javascript = {
+                enable = true;
+              };
 
-                  languages.typescript = {
-                    enable = true;
-                  };
+              languages.typescript = {
+                enable = true;
+              };
 
-                  # Make diffs fantastic
-                  difftastic.enable = true;
+              # Make diffs fantastic
+              difftastic.enable = true;
 
-                  # https://devenv.sh/pre-commit-hooks/
-                  pre-commit.hooks = {
-                    nixfmt.enable = true;
-                    yamllint.enable = true;
-                    editorconfig-checker.enable = true;
-                    prettier.enable = true;
-                  };
+              # https://devenv.sh/pre-commit-hooks/
+              pre-commit.hooks = {
+                nixfmt.enable = true;
+                yamllint = {
+                  enable = true;
+                  settings.preset = "relaxed";
+                };
+                editorconfig-checker.enable = true;
+                prettier.enable = true;
+              };
 
-                  # Plugin configuration
-                  pre-commit.settings = {
-                    yamllint.relaxed = true;
-                  };
-
-                  # https://devenv.sh/integrations/dotenv/
-                  dotenv.enable = true;
-
-                }
-              ];
-            };
-          });
-    };
+              # https://devenv.sh/integrations/dotenv/
+              dotenv.enable = true;
+            }
+          ];
+        };
+      });
+  };
 }

--- a/python/flake.nix
+++ b/python/flake.nix
@@ -15,25 +15,35 @@
     extra-substituters = "https://devenv.cachix.org";
   };
 
-  outputs = inputs@{ flake-parts, nixpkgs, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = inputs @ {
+    flake-parts,
+    nixpkgs,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       imports = [
         inputs.devenv.flakeModule
       ];
-      systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      systems = ["x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
 
-      perSystem = { config, self', inputs', pkgs, system, ... }:
-        let
-          python-packages = p:
-            with p; [
-              pip
-              python-lsp-server
-              importmagic
-              epc
-              black
-              mypy
-            ];
-        in {
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: let
+        python-packages = p:
+          with p; [
+            pip
+            python-lsp-server
+            importmagic
+            epc
+            black
+            mypy
+          ];
+      in {
         # Per-system attributes can be defined here. The self' and inputs'
         # module parameters provide easy access to attributes of the same
         # system.
@@ -48,11 +58,10 @@
           ];
 
           # https://devenv.sh/reference/options/
-          packages = with pkgs;
-            [
-              stdenv.cc.cc.lib # required by Jupyter
-              (python3.withPackages python-packages)
-            ];
+          packages = with pkgs; [
+            stdenv.cc.cc.lib # required by Jupyter
+            (python3.withPackages python-packages)
+          ];
 
           # https://devenv.sh/basics/
           env = {
@@ -84,27 +93,22 @@
           pre-commit.hooks = {
             black.enable = true;
             nixfmt.enable = true;
-            yamllint.enable = true;
+            yamllint = {
+              enable = true;
+              settings.preset = "relaxed";
+            };
             pyright.enable = true;
             editorconfig-checker.enable = true;
           };
 
-          # Plugin configuration
-          pre-commit.settings = {
-            yamllint.relaxed = true;
-          };
-
           # https://devenv.sh/integrations/dotenv/
           dotenv.enable = true;
-
         };
-
       };
       flake = {
         # The usual flake attributes can be defined here, including system-
         # agnostic ones like nixosModule and system-enumerating ones, although
         # those are more easily expressed in perSystem.
-
       };
     };
 }

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -19,20 +19,31 @@
     extra-substituters = "https://devenv.cachix.org";
   };
 
-  outputs = inputs@{ flake-parts, nixpkgs, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = inputs @ {
+    flake-parts,
+    nixpkgs,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       imports = [
         inputs.devenv.flakeModule
       ];
-      systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      systems = ["x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
 
-      perSystem = { config, self', inputs', lib, pkgs, system, ... }:
-        let
-          cargoBuildInputs = lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk; [
-            frameworks.Security
-            frameworks.CoreServices
-          ]);
-        in {
+      perSystem = {
+        config,
+        self',
+        inputs',
+        lib,
+        pkgs,
+        system,
+        ...
+      }: let
+        cargoBuildInputs = lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk; [
+          frameworks.Security
+          frameworks.CoreServices
+        ]);
+      in {
         # Per-system attributes can be defined here. The self' and inputs'
         # module parameters provide easy access to attributes of the same
         # system.
@@ -47,8 +58,7 @@
           ];
 
           # https://devenv.sh/reference/options/
-          packages = with pkgs;
-            [];
+          packages = with pkgs; [];
 
           # https://devenv.sh/basics/
           env = {
@@ -85,24 +95,20 @@
           # https://devenv.sh/pre-commit-hooks/
           pre-commit.hooks = {
             nixfmt.enable = true;
-            yamllint.enable = true;
-          };
-
-          # Plugin configuration
-          pre-commit.settings = {
-            yamllint.relaxed = true;
+            yamllint = {
+              enable = true;
+              settings.preset = "relaxed";
+            };
           };
 
           # https://devenv.sh/integrations/dotenv/
           dotenv.enable = true;
         };
-
       };
       flake = {
         # The usual flake attributes can be defined here, including system-
         # agnostic ones like nixosModule and system-enumerating ones, although
         # those are more easily expressed in perSystem.
-
       };
     };
 }

--- a/terraform/flake.nix
+++ b/terraform/flake.nix
@@ -14,14 +14,25 @@
     extra-substituters = "https://devenv.cachix.org";
   };
 
-  outputs = inputs@{ flake-parts, nixpkgs, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = inputs @ {
+    flake-parts,
+    nixpkgs,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       imports = [
         inputs.devenv.flakeModule
       ];
-      systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      systems = ["x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
 
-      perSystem = { config, self', inputs', pkgs, system, ... }: {
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: {
         # https://github.com/cachix/devenv/issues/521
         _module.args.pkgs = import nixpkgs {
           inherit system;
@@ -40,7 +51,7 @@
           ];
 
           # https://devenv.sh/reference/options/
-          packages = with pkgs; [ ];
+          packages = with pkgs; [];
 
           # https://devenv.sh/basics/
           env = {
@@ -64,26 +75,22 @@
           pre-commit.hooks = {
             shellcheck.enable = true;
             nixfmt.enable = true;
-            yamllint.enable = true;
+            yamllint = {
+              enable = true;
+              settings.preset = "relaxed";
+            };
             terraform-format.enable = true;
             tflint.enable = true;
-          };
-
-          # Plugin configuration
-          pre-commit.settings = {
-            yamllint.relaxed = true;
           };
 
           # https://devenv.sh/integrations/dotenv/
           dotenv.enable = true;
         };
-
       };
       flake = {
         # The usual flake attributes can be defined here, including system-
         # agnostic ones like nixosModule and system-enumerating ones, although
         # those are more easily expressed in perSystem.
-
       };
     };
 }


### PR DESCRIPTION
The option for declaring the yamllint preset was changed in [this pr](https://github.com/cachix/git-hooks.nix/pull/398) which led to the environments failing to build.

Also worth noting a new option was added alongside that merge (settings.yamllint.strict) which defaults to true.

(This is my first pr, so apologies if anything is amiss)

